### PR TITLE
Fix tests for mixin refactor

### DIFF
--- a/backend/agents/cinegraph_agent.py
+++ b/backend/agents/cinegraph_agent.py
@@ -187,6 +187,11 @@ class CineGraphAgent(StoryAnalysisAgent, AlertManager, GraphQueryTools):
         self.system_prompt = self._build_enhanced_system_prompt()
         self.tool_schemas = self._build_enhanced_tool_schemas()
         self._setup_redis_alerts()
+
+    async def initialize(self) -> None:
+        """Perform asynchronous setup tasks."""
+        if self.graphiti_manager and hasattr(self.graphiti_manager, "initialize"):
+            await self.graphiti_manager.initialize()
     
     def _load_schema_context(self) -> Dict[str, Any]:
         """Load and parse the complete CineGraph schema for enhanced query generation."""


### PR DESCRIPTION
## Summary
- patch cinegraph agent tests for mixin-based alert manager
- add minimal `initialize` method to agent
- adjust tests to use new environment variable and query parameters

## Testing
- `pytest backend/tests/test_cinegraph_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687051564c248327b7e212d09294c00e