### PR TITLE
Add specialized SDK agents

### DIFF
--- a/backend/sdk_agents/__init__.py
+++ b/backend/sdk_agents/__init__.py
@@ -1,0 +1,19 @@
+from .story_query_agent import StoryQueryAgent
+from .inconsistency_explainer_agent import InconsistencyExplainerAgent
+from .character_analysis_agent import CharacterAnalysisAgent
+from .story_input_agent import StoryInputAgent
+from .rpg_maker_agent import RPGMakerAgent
+from .tutorial_agent import TutorialAgent
+from .results_interpreter_agent import ResultsInterpreterAgent
+from .story_debugging_agent import StoryDebuggingAgent
+
+__all__ = [
+    "StoryQueryAgent",
+    "InconsistencyExplainerAgent",
+    "CharacterAnalysisAgent",
+    "StoryInputAgent",
+    "RPGMakerAgent",
+    "TutorialAgent",
+    "ResultsInterpreterAgent",
+    "StoryDebuggingAgent",
+]

--- a/backend/sdk_agents/character_analysis_agent.py
+++ b/backend/sdk_agents/character_analysis_agent.py
@@ -1,0 +1,13 @@
+"""CharacterAnalysisAgent definition."""
+from agents.agent import Agent
+from .tools import query_cinegraph_core, get_character_knowledge, detect_contradictions
+
+class CharacterAnalysisAgent(Agent):
+    """Assist with character knowledge timelines and comparisons."""
+
+    name = "Character Knowledge Assistant"
+    instructions = """
+    You help creators understand what their characters know and when they learned it.
+    Explain character development and knowledge evolution clearly.
+    """
+    tools = [query_cinegraph_core, get_character_knowledge, detect_contradictions]

--- a/backend/sdk_agents/inconsistency_explainer_agent.py
+++ b/backend/sdk_agents/inconsistency_explainer_agent.py
@@ -1,0 +1,13 @@
+"""InconsistencyExplainerAgent definition."""
+from agents.agent import Agent
+from .tools import query_cinegraph_core, get_character_knowledge, detect_contradictions
+
+class InconsistencyExplainerAgent(Agent):
+    """Explain story contradictions with fix suggestions."""
+
+    name = "Inconsistency Explainer"
+    instructions = """
+    You explain story inconsistencies in clear, actionable terms for RPG Maker creators.
+    Provide specific suggestions for fixing contradictions.
+    """
+    tools = [query_cinegraph_core, get_character_knowledge, detect_contradictions]

--- a/backend/sdk_agents/results_interpreter_agent.py
+++ b/backend/sdk_agents/results_interpreter_agent.py
@@ -1,0 +1,13 @@
+"""ResultsInterpreterAgent definition."""
+from agents.agent import Agent
+from .tools import query_cinegraph_core, get_character_knowledge, detect_contradictions
+
+class ResultsInterpreterAgent(Agent):
+    """Translate analysis results into actionable insights."""
+
+    name = "Analysis Results Interpreter"
+    instructions = """
+    You translate complex CineGraph analysis results into actionable insights
+    for story creators, focusing on practical improvements.
+    """
+    tools = [query_cinegraph_core, get_character_knowledge, detect_contradictions]

--- a/backend/sdk_agents/rpg_maker_agent.py
+++ b/backend/sdk_agents/rpg_maker_agent.py
@@ -1,0 +1,13 @@
+"""RPGMakerAgent definition."""
+from agents.agent import Agent
+from .tools import query_cinegraph_core, get_character_knowledge, detect_contradictions
+
+class RPGMakerAgent(Agent):
+    """Assist with exporting analysis to RPG Maker formats."""
+
+    name = "RPG Maker Integration Assistant"
+    instructions = """
+    You help users export CineGraph analysis results to RPG Maker formats
+    and integrate story consistency checks into their development workflow.
+    """
+    tools = [query_cinegraph_core, get_character_knowledge, detect_contradictions]

--- a/backend/sdk_agents/story_debugging_agent.py
+++ b/backend/sdk_agents/story_debugging_agent.py
@@ -1,0 +1,13 @@
+"""StoryDebuggingAgent definition."""
+from agents.agent import Agent
+from .tools import query_cinegraph_core, get_character_knowledge, detect_contradictions
+
+class StoryDebuggingAgent(Agent):
+    """Assist users in debugging story issues systematically."""
+
+    name = "Story Debugging Assistant"
+    instructions = """
+    You help users identify and fix complex story issues, guide them through
+    debugging workflows, and suggest systematic approaches to story problems.
+    """
+    tools = [query_cinegraph_core, get_character_knowledge, detect_contradictions]

--- a/backend/sdk_agents/story_input_agent.py
+++ b/backend/sdk_agents/story_input_agent.py
@@ -1,0 +1,13 @@
+"""StoryInputAgent definition."""
+from agents.agent import Agent
+from .tools import query_cinegraph_core, get_character_knowledge, detect_contradictions
+
+class StoryInputAgent(Agent):
+    """Guide users through story input with validation."""
+
+    name = "Story Input Assistant"
+    instructions = """
+    You guide users through story input, help format content, and provide
+    real-time feedback during story creation.
+    """
+    tools = [query_cinegraph_core, get_character_knowledge, detect_contradictions]

--- a/backend/sdk_agents/story_query_agent.py
+++ b/backend/sdk_agents/story_query_agent.py
@@ -1,0 +1,13 @@
+"""StoryQueryAgent definition."""
+from agents.agent import Agent
+from .tools import query_cinegraph_core, get_character_knowledge, detect_contradictions
+
+class StoryQueryAgent(Agent):
+    """Natural language query agent for story questions."""
+
+    name = "Story Query Assistant"
+    instructions = """
+    You help RPG Maker creators ask questions about their stories in natural language.
+    Convert user questions into CineGraph analysis requests.
+    """
+    tools = [query_cinegraph_core, get_character_knowledge, detect_contradictions]

--- a/backend/sdk_agents/tools.py
+++ b/backend/sdk_agents/tools.py
@@ -1,0 +1,38 @@
+"""Helper tool wrappers for SDK agents."""
+from __future__ import annotations
+
+import os
+from agents.tool import function_tool
+from core.graphiti_manager import GraphitiManager
+
+# Global GraphitiManager instance used by tools
+_graphiti_manager = GraphitiManager()
+
+async def _ensure_connected() -> None:
+    """Ensure the GraphitiManager is initialized."""
+    if _graphiti_manager.client is None:
+        await _graphiti_manager.initialize()
+
+@function_tool
+async def query_cinegraph_core(query: str, story_id: str) -> dict:
+    """Tool for SDK agents to access the core analysis engine."""
+    await _ensure_connected()
+    return await _graphiti_manager._run_cypher_query(query)
+
+DEFAULT_STORY_ID = os.getenv("DEFAULT_STORY_ID", "demo_story")
+
+@function_tool
+async def get_character_knowledge(character: str, timestamp: str) -> dict:
+    """Tool to get character knowledge at specific time."""
+    await _ensure_connected()
+    knowledge = await _graphiti_manager.get_character_knowledge(
+        DEFAULT_STORY_ID, character, timestamp, user_id="sdk_agent"
+    )
+    return knowledge.model_dump() if hasattr(knowledge, "model_dump") else knowledge.__dict__
+
+@function_tool
+async def detect_contradictions(story_id: str) -> list:
+    """Tool to run contradiction detection."""
+    await _ensure_connected()
+    result = await _graphiti_manager.detect_contradictions(story_id, user_id="sdk_agent")
+    return result.get("result", [])

--- a/backend/sdk_agents/tutorial_agent.py
+++ b/backend/sdk_agents/tutorial_agent.py
@@ -1,0 +1,13 @@
+"""TutorialAgent definition."""
+from agents.agent import Agent
+from .tools import query_cinegraph_core, get_character_knowledge, detect_contradictions
+
+class TutorialAgent(Agent):
+    """Guide new users through CineGraph features."""
+
+    name = "CineGraph Tutorial Assistant"
+    instructions = """
+    You guide new users through CineGraph features and help them understand
+    story analysis concepts in an approachable way.
+    """
+    tools = [query_cinegraph_core, get_character_knowledge, detect_contradictions]


### PR DESCRIPTION
## Summary
- add new SDK agent modules implementing `Agent` subclasses
- expose tool wrappers and agent imports

## Testing
- `pytest backend/tests/test_cinegraph_agent.py::test_agent_inherits_mixins -q` *(fails: `ImportError: cannot import name 'create_client' from 'supabase'`)*

------
https://chatgpt.com/codex/tasks/task_e_68705ef6a4348327885c4f9b96a2dc72