### PR TITLE
Add docstring for SDK agent tools

### DIFF
--- a/backend/sdk_agents/tools.py
+++ b/backend/sdk_agents/tools.py
@@ -1,4 +1,8 @@
-"""Helper tool wrappers for SDK agents."""
+"""Helper tool wrappers for SDK agents.
+
+These wrappers expose a minimal interface for accessing CineGraph core
+functionality via :class:`GraphitiManager`.
+"""
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Summary
- add detailed docstring to `backend/sdk_agents/tools.py`

## Testing
- `pytest backend/test_simple_integration.py::test_basic_api_integration -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_687065c06c948327b163f54d39ccc162