### PR TITLE
Fix agent handoff cleanup

### DIFF
--- a/backend/sdk_agents/manager.py
+++ b/backend/sdk_agents/manager.py
@@ -122,4 +122,5 @@ class SDKAgentManager:
         )
         self._current_agent = result.last_agent
         self._input_items = result.to_input_list()
+        self._clear_handoffs()
         return result.final_output_as(str)


### PR DESCRIPTION
## Summary
- ensure SDKAgentManager clears agent handoffs after Runner.run

## Testing
- `pytest -k sdk_agents/manager.py` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_6870793e9df08327aa005afa250a2741