### PR TITLE
Add openai-agents dependency

### DIFF
--- a/backend/README_CINEGRAPH_AGENT.md
+++ b/backend/README_CINEGRAPH_AGENT.md
@@ -74,7 +74,7 @@ REDIS_DB=0
 
 1. Install required dependencies:
 ```bash
-pip install openai-agents graphiti-core supabase redis celery
+pip install openai-agents==0.1.0 graphiti-core supabase redis celery
 ```
 
 2. Set up the Supabase alerts table:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,4 @@ supabase==2.3.4
 asyncpg==0.29.0
 websockets==12.0
 pre-commit==3.6.0
+openai-agents==0.1.0


### PR DESCRIPTION
## Summary
- pin `openai-agents==0.1.0` in requirements
- document new dependency in agent README

## Testing
- `pip install -r backend/requirements.txt` *(fails: numpy does not support Python 3.12)*

------
https://chatgpt.com/codex/tasks/task_e_687080aa9dbc8327b919f1a5fe4f2804