### PR TITLE
Add RPG variable models and generator

### DIFF
--- a/backend/game/models.py
+++ b/backend/game/models.py
@@ -97,3 +97,54 @@ class ExportConfiguration(BaseModel):
     )
 
 
+class VariableDataType(str, Enum):
+    """Supported data types for RPG variables."""
+
+    INTEGER = "integer"
+    FLOAT = "float"
+    STRING = "string"
+    BOOLEAN = "boolean"
+
+
+class VariableScope(str, Enum):
+    """Scope levels for RPG variables."""
+
+    GAME = "game"
+    MAP = "map"
+    EVENT = "event"
+
+
+class SwitchScope(str, Enum):
+    """Scope levels for RPG switches."""
+
+    GLOBAL = "global"
+    LOCAL = "local"
+
+
+class RPGVariable(BaseModel):
+    """Represents a variable in an RPG project."""
+
+    name: str = Field(..., description="Variable name")
+    value: Optional[str | int | float | bool] = Field(
+        default=None, description="Initial value of the variable"
+    )
+    data_type: VariableDataType = Field(
+        default=VariableDataType.INTEGER, description="Data type of the variable"
+    )
+    scope: VariableScope = Field(
+        default=VariableScope.GAME, description="Scope of the variable"
+    )
+    description: Optional[str] = Field(default=None, description="Variable description")
+
+
+class RPGSwitch(BaseModel):
+    """Represents a boolean switch in an RPG project."""
+
+    name: str = Field(..., description="Switch name")
+    is_on: bool = Field(default=False, description="Initial state of the switch")
+    scope: SwitchScope = Field(
+        default=SwitchScope.GLOBAL, description="Scope of the switch"
+    )
+    description: Optional[str] = Field(default=None, description="Switch description")
+
+

--- a/backend/game/variable_generator.py
+++ b/backend/game/variable_generator.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Utility for generating RPG variables and switches from story data."""
+
+from typing import List, Dict, Any
+
+from .models import (
+    RPGVariable,
+    RPGSwitch,
+    VariableScope,
+    VariableDataType,
+    SwitchScope,
+)
+
+
+class StoryVariableGenerator:
+    """Generate RPG variables and switches using a CineGraphAgent."""
+
+    def __init__(self, agent: Any) -> None:
+        self.agent = agent
+
+    async def generate_variables(self, story_id: str) -> List[RPGVariable]:
+        """Fetch variable data via the agent and return ``RPGVariable`` objects."""
+        query = "MATCH (v:RPGVariable {story_id: $story_id}) RETURN v"
+        result = await self.agent.graph_query(query, {"story_id": story_id})
+        variables: List[RPGVariable] = []
+        if result.get("success"):
+            for item in result.get("data", []):
+                data = item.get("v", item)
+                variables.append(RPGVariable(**data))
+        return variables
+
+    async def generate_switches(self, story_id: str) -> List[RPGSwitch]:
+        """Fetch switch data via the agent and return ``RPGSwitch`` objects."""
+        query = "MATCH (s:RPGSwitch {story_id: $story_id}) RETURN s"
+        result = await self.agent.graph_query(query, {"story_id": story_id})
+        switches: List[RPGSwitch] = []
+        if result.get("success"):
+            for item in result.get("data", []):
+                data = item.get("s", item)
+                switches.append(RPGSwitch(**data))
+        return switches

--- a/backend/tests/test_variable_generator.py
+++ b/backend/tests/test_variable_generator.py
@@ -1,0 +1,70 @@
+"""Tests for StoryVariableGenerator."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from game.variable_generator import StoryVariableGenerator
+from game.models import (
+    RPGVariable,
+    RPGSwitch,
+    VariableDataType,
+    VariableScope,
+    SwitchScope,
+)
+
+
+@pytest.mark.asyncio
+async def test_generate_variables_and_switches():
+    agent = Mock()
+    agent.graph_query = AsyncMock(side_effect=[
+        {
+            "success": True,
+            "data": [
+                {
+                    "name": "HeroHP",
+                    "value": 50,
+                    "data_type": "integer",
+                    "scope": "game",
+                    "description": "Hero health",
+                }
+            ],
+        },
+        {
+            "success": True,
+            "data": [
+                {
+                    "name": "DoorOpen",
+                    "is_on": True,
+                    "scope": "global",
+                    "description": "State of the door",
+                }
+            ],
+        },
+    ])
+
+    generator = StoryVariableGenerator(agent)
+
+    variables = await generator.generate_variables("story1")
+    switches = await generator.generate_switches("story1")
+
+    assert agent.graph_query.call_count == 2
+
+    assert len(variables) == 1
+    var = variables[0]
+    assert isinstance(var, RPGVariable)
+    assert var.name == "HeroHP"
+    assert var.value == 50
+    assert var.data_type == VariableDataType.INTEGER
+    assert var.scope == VariableScope.GAME
+
+    assert len(switches) == 1
+    sw = switches[0]
+    assert isinstance(sw, RPGSwitch)
+    assert sw.name == "DoorOpen"
+    assert sw.is_on is True
+    assert sw.scope == SwitchScope.GLOBAL


### PR DESCRIPTION
## Summary
- extend game models with variable and switch enums & classes
- implement `StoryVariableGenerator`
- test variable generation with a mock CineGraphAgent

## Testing
- `pytest backend/tests/test_game_models.py backend/tests/test_variable_generator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873eaa8618883278f2dfe339c031839