### PR TITLE
Add RPG character models and enhancer

### DIFF
--- a/backend/game/character_enhancer.py
+++ b/backend/game/character_enhancer.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Utility for enhancing character information from story analysis."""
+
+from typing import Any, List
+
+from .models import RPGCharacter
+
+
+class StoryCharacterEnhancer:
+    """Enhance story characters using a CineGraph agent."""
+
+    def __init__(self, agent: Any) -> None:
+        self.agent = agent
+
+    async def enhance_characters(self, story_id: str) -> List[RPGCharacter]:
+        """Generate ``RPGCharacter`` objects using the provided agent.
+
+        The agent is expected to expose an ``analyze_story_characters`` method
+        that returns a dictionary with a ``characters`` list. Each list item
+        should be compatible with :class:`RPGCharacter`.
+        """
+        result = await self.agent.analyze_story_characters(story_id)
+        characters: List[RPGCharacter] = []
+        for data in result.get("characters", []):
+            characters.append(RPGCharacter(**data))
+        return characters

--- a/backend/game/models.py
+++ b/backend/game/models.py
@@ -148,3 +148,35 @@ class RPGSwitch(BaseModel):
     description: Optional[str] = Field(default=None, description="Switch description")
 
 
+class RPGCharacterType(str, Enum):
+    """Types of RPG characters."""
+
+    HERO = "hero"
+    VILLAIN = "villain"
+    COMPANION = "companion"
+    NPC = "npc"
+    OTHER = "other"
+
+
+class CharacterStats(BaseModel):
+    """Basic RPG-style character statistics."""
+
+    hp: int = Field(default=100, description="Hit points")
+    mp: int = Field(default=0, description="Magic points")
+    strength: int = Field(default=10, description="Physical power")
+    agility: int = Field(default=10, description="Dexterity and speed")
+    intelligence: int = Field(default=10, description="Mental acuity")
+    charisma: int = Field(default=10, description="Social aptitude")
+
+
+class RPGCharacter(BaseModel):
+    """Represents a playable or non-playable character."""
+
+    name: str = Field(..., description="Character name")
+    type: RPGCharacterType = Field(default=RPGCharacterType.NPC, description="Character type")
+    level: int = Field(default=1, description="Character level")
+    stats: CharacterStats = Field(default_factory=CharacterStats, description="Character statistics")
+    knowledge_state: list[dict] = Field(default_factory=list, description="Known facts or memories")
+    description: Optional[str] = Field(default=None, description="Character description")
+
+

--- a/backend/tests/test_character_enhancer.py
+++ b/backend/tests/test_character_enhancer.py
@@ -1,0 +1,51 @@
+"""Tests for StoryCharacterEnhancer."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from game.character_enhancer import StoryCharacterEnhancer
+from game.models import RPGCharacter
+
+
+@pytest.mark.asyncio
+async def test_enhance_characters_populates_stats_and_knowledge():
+    agent = Mock()
+    agent.analyze_story_characters = AsyncMock(return_value={
+        "characters": [
+            {
+                "name": "Alice",
+                "type": "hero",
+                "level": 5,
+                "stats": {
+                    "hp": 120,
+                    "mp": 30,
+                    "strength": 15,
+                    "agility": 12,
+                    "intelligence": 14,
+                    "charisma": 11,
+                },
+                "knowledge_state": [
+                    {"id": "k1", "content": "Alice knows the prophecy"}
+                ],
+            }
+        ]
+    })
+
+    enhancer = StoryCharacterEnhancer(agent)
+    characters = await enhancer.enhance_characters("story1")
+
+    agent.analyze_story_characters.assert_called_once_with("story1")
+    assert len(characters) == 1
+
+    char = characters[0]
+    assert isinstance(char, RPGCharacter)
+    assert char.name == "Alice"
+    assert char.stats.hp == 120
+    assert char.stats.strength == 15
+    assert len(char.knowledge_state) == 1
+    assert char.knowledge_state[0]["content"] == "Alice knows the prophecy"

--- a/backend/tests/test_game_models.py
+++ b/backend/tests/test_game_models.py
@@ -10,6 +10,9 @@ from game.models import (
     ExportFormat,
     RPGProject,
     ExportConfiguration,
+    RPGCharacter,
+    RPGCharacterType,
+    CharacterStats,
 )
 
 
@@ -32,4 +35,13 @@ def test_export_configuration_defaults():
     assert config.output_path == "./export"
     assert config.validate_before_export is True
     assert config.validation_level == ValidationLevel.BASIC
+
+
+def test_rpg_character_defaults():
+    char = RPGCharacter(name="Hero")
+    assert char.type == RPGCharacterType.NPC
+    assert char.level == 1
+    assert isinstance(char.stats, CharacterStats)
+    assert char.stats.hp == 100
+    assert char.knowledge_state == []
 


### PR DESCRIPTION
## Summary
- define RPGCharacter, CharacterStats and RPGCharacterType models
- implement StoryCharacterEnhancer for generating characters
- test RPGCharacter defaults
- test StoryCharacterEnhancer populates stats and knowledge

## Testing
- `pytest -q tests/test_character_enhancer.py tests/test_game_models.py tests/test_variable_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6873ef5d2444832781ddc5da54073f8b