### PR TITLE
Add location enhancer utilities

### DIFF
--- a/backend/game/location_enhancer.py
+++ b/backend/game/location_enhancer.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Utility for enhancing location information from story analysis."""
+
+from typing import Any, List, Tuple
+
+from .models import RPGLocation, LocationConnection
+
+
+class StoryLocationEnhancer:
+    """Enhance story locations using a CineGraph agent."""
+
+    def __init__(self, agent: Any) -> None:
+        self.agent = agent
+
+    async def enhance_locations(self, story_id: str) -> Tuple[List[RPGLocation], List[LocationConnection]]:
+        """Generate ``RPGLocation`` and ``LocationConnection`` objects using the provided agent.
+
+        The agent is expected to expose an ``analyze_story_locations`` method that
+        returns a dictionary with ``locations`` and ``connections`` lists.
+        """
+        result = await self.agent.analyze_story_locations(story_id)
+        locations: List[RPGLocation] = []
+        connections: List[LocationConnection] = []
+
+        for data in result.get("locations", []):
+            locations.append(RPGLocation(**data))
+        for data in result.get("connections", []):
+            connections.append(LocationConnection(**data))
+
+        return locations, connections

--- a/backend/game/models.py
+++ b/backend/game/models.py
@@ -180,3 +180,51 @@ class RPGCharacter(BaseModel):
     description: Optional[str] = Field(default=None, description="Character description")
 
 
+class LocationType(str, Enum):
+    """Types of locations within an RPG world."""
+
+    TOWN = "town"
+    DUNGEON = "dungeon"
+    BUILDING = "building"
+    WILDERNESS = "wilderness"
+    OTHER = "other"
+
+
+class ConnectionType(str, Enum):
+    """Ways locations can be connected."""
+
+    PATH = "path"
+    DOOR = "door"
+    PORTAL = "portal"
+    OTHER = "other"
+
+
+class Direction(str, Enum):
+    """Cardinal or relative directions for connections."""
+
+    NORTH = "north"
+    SOUTH = "south"
+    EAST = "east"
+    WEST = "west"
+    UP = "up"
+    DOWN = "down"
+
+
+class RPGLocation(BaseModel):
+    """Represents a location within the story world."""
+
+    name: str = Field(..., description="Location name")
+    type: LocationType = Field(default=LocationType.OTHER, description="Location type")
+    description: Optional[str] = Field(default=None, description="Location description")
+    events: list[str] = Field(default_factory=list, description="Story events that occur here")
+
+
+class LocationConnection(BaseModel):
+    """Connection from one location to another."""
+
+    from_location: str = Field(..., description="Starting location name")
+    to_location: str = Field(..., description="Destination location name")
+    type: ConnectionType = Field(default=ConnectionType.PATH, description="Connection type")
+    direction: Optional[Direction] = Field(default=None, description="Direction from start to destination")
+
+

--- a/backend/tests/test_location_enhancer.py
+++ b/backend/tests/test_location_enhancer.py
@@ -1,0 +1,61 @@
+"""Tests for StoryLocationEnhancer."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from game.location_enhancer import StoryLocationEnhancer
+from game.models import (
+    RPGLocation,
+    LocationConnection,
+    LocationType,
+    ConnectionType,
+    Direction,
+)
+
+
+@pytest.mark.asyncio
+async def test_enhance_locations_returns_events_and_connections():
+    agent = Mock()
+    agent.analyze_story_locations = AsyncMock(return_value={
+        "locations": [
+            {
+                "name": "Town",
+                "type": "town",
+                "description": "A peaceful town",
+                "events": ["Festival"],
+            }
+        ],
+        "connections": [
+            {
+                "from_location": "Town",
+                "to_location": "Forest",
+                "type": "path",
+                "direction": "north",
+            }
+        ],
+    })
+
+    enhancer = StoryLocationEnhancer(agent)
+    locations, connections = await enhancer.enhance_locations("story1")
+
+    agent.analyze_story_locations.assert_called_once_with("story1")
+
+    assert len(locations) == 1
+    loc = locations[0]
+    assert isinstance(loc, RPGLocation)
+    assert loc.name == "Town"
+    assert loc.type == LocationType.TOWN
+    assert loc.events == ["Festival"]
+
+    assert len(connections) == 1
+    conn = connections[0]
+    assert isinstance(conn, LocationConnection)
+    assert conn.from_location == "Town"
+    assert conn.to_location == "Forest"
+    assert conn.type == ConnectionType.PATH
+    assert conn.direction == Direction.NORTH


### PR DESCRIPTION
## Summary
- extend game models with location and connection structures
- implement `StoryLocationEnhancer` helper
- test derivation of locations and connections from mock data

## Testing
- `pytest -q backend/tests/test_location_enhancer.py`
- `pytest -q backend/tests/test_character_enhancer.py backend/tests/test_variable_generator.py backend/tests/test_location_enhancer.py`


------
https://chatgpt.com/codex/tasks/task_e_6873f2ee4b848327828930dcaca0f9f2