### PR TITLE
Implement RPG variable & switch API endpoints

### DIFF
--- a/backend/tests/test_rpg_projects.py
+++ b/backend/tests/test_rpg_projects.py
@@ -4,6 +4,7 @@ import types
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock, patch
+from game.models import RPGVariable
 
 # Ensure project modules are importable
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -87,3 +88,82 @@ def test_project_workflow(client):
     data = resp.json()
     assert isinstance(data["export_configs"], list)
     assert len(data["export_configs"]) == 1
+
+
+def test_variable_and_switch_endpoints(client):
+    project_data = {"name": "Vars", "version": "MZ", "genre": "fantasy"}
+    resp = client.post("/api/rpg-projects", json=project_data)
+    project_id = resp.json()["project_id"]
+
+    variable = {
+        "name": "Gold",
+        "value": 10,
+        "data_type": "integer",
+        "scope": "game",
+        "description": "Player gold",
+    }
+    resp = client.post(f"/api/rpg-projects/{project_id}/variables", json=variable)
+    assert resp.status_code == 200
+    assert len(rpg_projects[project_id]["variables"]) == 1
+
+    resp = client.get(f"/api/rpg-projects/{project_id}/variables")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data["variables"], list)
+    assert data["variables"][0]["name"] == "Gold"
+
+    switch = {"name": "Door", "is_on": False, "scope": "global"}
+    resp = client.post(f"/api/rpg-projects/{project_id}/switches", json=switch)
+    assert resp.status_code == 200
+    assert len(rpg_projects[project_id]["switches"]) == 1
+
+    resp = client.get(f"/api/rpg-projects/{project_id}/switches")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["switches"][0]["name"] == "Door"
+
+
+def test_generate_and_sync_variables(client):
+    project_data = {"name": "Generate", "version": "MZ", "genre": "fantasy"}
+    resp = client.post("/api/rpg-projects", json=project_data)
+    project_id = resp.json()["project_id"]
+
+    story = {"story_id": "s1", "content": "The hero enters."}
+    client.post(f"/api/rpg-projects/{project_id}/sync-story", json=story)
+
+    with patch("app.main.StoryVariableGenerator") as MockGen:
+        mock_gen = MockGen.return_value
+        mock_gen.generate_variables = AsyncMock(return_value=[
+            RPGVariable(
+                name="HeroHP",
+                value=50,
+                data_type="integer",
+                scope="game",
+                description="HP",
+            )
+        ])
+
+        resp = client.post(
+            f"/api/rpg-projects/{project_id}/variables/generate-from-story"
+        )
+        assert resp.status_code == 200
+        assert len(rpg_projects[project_id]["variables"]) == 1
+
+        mock_gen.generate_variables.assert_called_once()
+
+        mock_gen.generate_variables = AsyncMock(return_value=[
+            RPGVariable(
+                name="HeroHP",
+                value=75,
+                data_type="integer",
+                scope="game",
+                description="HP",
+            )
+        ])
+
+        resp = client.post(
+            f"/api/rpg-projects/{project_id}/variables/HeroHP/story-sync"
+        )
+        assert resp.status_code == 200
+        assert rpg_projects[project_id]["variables"][0].value == 75
+


### PR DESCRIPTION
## Summary
- extend project creation to track variables & switches
- add endpoints for managing project variables and switches
- generate variables using `StoryVariableGenerator`
- update project tests for new functionality

## Testing
- `pytest tests/test_rpg_projects.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687407c26ce08327bbd3ee9a2f37a29e