### PR TITLE
RPG endpoints now use Neo4j storage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,12 @@ GRAPHITI_DATABASE_NAME=neo4j
 GRAPHITI_MAX_CONNECTIONS=10
 GRAPHITI_CONNECTION_TIMEOUT=30
 
+# Neo4j URI Configuration (alternative names used by some scripts)
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=your_neo4j_password_here
+NEO4J_DATABASE=neo4j
+
 # OpenAI Configuration
 OPENAI_MODEL=gpt-4-turbo-preview
 OPENAI_MAX_TOKENS=4000

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -77,3 +77,135 @@ async def background_job(graphiti_instance):
     """Create BackgroundConsistencyJob instance for testing."""
     return BackgroundConsistencyJob(graphiti_instance)
 
+
+@pytest.fixture(autouse=True)
+def rpg_graphiti_store(monkeypatch):
+    """Mock GraphitiManager for RPG endpoint tests."""
+    from app.main import graphiti_manager
+    store = {}
+
+    async def create_rpg_project(project):
+        pid = f"proj_{len(store)+1}"
+        store[pid] = {
+            "project": project,
+            "stories": {},
+            "export_configs": [],
+            "variables": [],
+            "switches": [],
+            "characters": [],
+            "locations": [],
+            "location_connections": [],
+        }
+        return pid
+
+    async def sync_project_story(pid, story):
+        store[pid]["stories"][story.story_id] = story.content
+
+    async def get_project_story_ids(pid):
+        return list(store.get(pid, {}).get("stories", {}).keys())
+
+    async def get_project_story_content(pid, sid):
+        return store[pid]["stories"][sid]
+
+    async def add_export_config(pid, cfg):
+        store[pid]["export_configs"].append(cfg)
+
+    async def get_export_configs(pid):
+        return store[pid]["export_configs"]
+
+    async def add_project_variable(pid, var):
+        store[pid]["variables"].append(var)
+
+    async def get_project_variables(pid):
+        return store[pid]["variables"]
+
+    async def replace_project_variables(pid, vars):
+        store[pid]["variables"] = list(vars)
+
+    async def update_project_variable(pid, var):
+        for idx, v in enumerate(store[pid]["variables"]):
+            if v.name == var.name:
+                store[pid]["variables"][idx] = var
+
+    async def add_project_switch(pid, sw):
+        store[pid]["switches"].append(sw)
+
+    async def get_project_switches(pid):
+        return store[pid]["switches"]
+
+    async def add_project_character(pid, char):
+        store[pid]["characters"].append(char)
+
+    async def get_project_characters(pid):
+        return store[pid]["characters"]
+
+    async def replace_project_characters(pid, chars):
+        store[pid]["characters"] = list(chars)
+
+    async def update_project_character(pid, char):
+        for idx, c in enumerate(store[pid]["characters"]):
+            if c.name == char.name:
+                store[pid]["characters"][idx] = char
+
+    async def get_character_knowledge_state(pid, cid):
+        for c in store[pid]["characters"]:
+            if c.name == cid:
+                return c.knowledge_state
+        return []
+
+    async def update_character_knowledge_state(pid, cid, knowledge):
+        for c in store[pid]["characters"]:
+            if c.name == cid:
+                c.knowledge_state = knowledge
+
+    async def add_project_location(pid, loc):
+        store[pid]["locations"].append(loc)
+
+    async def get_project_locations(pid):
+        return store[pid]["locations"]
+
+    async def replace_project_locations(pid, locs):
+        store[pid]["locations"] = list(locs)
+
+    async def update_project_location(pid, loc):
+        for idx, l in enumerate(store[pid]["locations"]):
+            if l.name == loc.name:
+                store[pid]["locations"][idx] = loc
+
+    async def add_location_connection(pid, conn):
+        store[pid]["location_connections"].append(conn)
+
+    async def replace_location_connections(pid, conns):
+        store[pid]["location_connections"] = list(conns)
+
+    async def get_location_connections(pid, lid):
+        return [c for c in store[pid]["location_connections"] if c.from_location == lid or c.to_location == lid]
+
+    monkeypatch.setattr(graphiti_manager, "create_rpg_project", create_rpg_project)
+    monkeypatch.setattr(graphiti_manager, "sync_project_story", sync_project_story)
+    monkeypatch.setattr(graphiti_manager, "get_project_story_ids", get_project_story_ids)
+    monkeypatch.setattr(graphiti_manager, "get_project_story_content", get_project_story_content)
+    monkeypatch.setattr(graphiti_manager, "add_export_config", add_export_config)
+    monkeypatch.setattr(graphiti_manager, "get_export_configs", get_export_configs)
+    monkeypatch.setattr(graphiti_manager, "add_project_variable", add_project_variable)
+    monkeypatch.setattr(graphiti_manager, "get_project_variables", get_project_variables)
+    monkeypatch.setattr(graphiti_manager, "replace_project_variables", replace_project_variables)
+    monkeypatch.setattr(graphiti_manager, "update_project_variable", update_project_variable)
+    monkeypatch.setattr(graphiti_manager, "add_project_switch", add_project_switch)
+    monkeypatch.setattr(graphiti_manager, "get_project_switches", get_project_switches)
+    monkeypatch.setattr(graphiti_manager, "add_project_character", add_project_character)
+    monkeypatch.setattr(graphiti_manager, "get_project_characters", get_project_characters)
+    monkeypatch.setattr(graphiti_manager, "replace_project_characters", replace_project_characters)
+    monkeypatch.setattr(graphiti_manager, "update_project_character", update_project_character)
+    monkeypatch.setattr(graphiti_manager, "get_character_knowledge_state", get_character_knowledge_state)
+    monkeypatch.setattr(graphiti_manager, "update_character_knowledge_state", update_character_knowledge_state)
+    monkeypatch.setattr(graphiti_manager, "add_project_location", add_project_location)
+    monkeypatch.setattr(graphiti_manager, "get_project_locations", get_project_locations)
+    monkeypatch.setattr(graphiti_manager, "replace_project_locations", replace_project_locations)
+    monkeypatch.setattr(graphiti_manager, "update_project_location", update_project_location)
+    monkeypatch.setattr(graphiti_manager, "add_location_connection", add_location_connection)
+    monkeypatch.setattr(graphiti_manager, "replace_location_connections", replace_location_connections)
+    monkeypatch.setattr(graphiti_manager, "get_location_connections", get_location_connections)
+
+    yield store
+

--- a/backend/tests/test_rpg_projects.py
+++ b/backend/tests/test_rpg_projects.py
@@ -36,11 +36,11 @@ tool_mod = types.ModuleType("agents.tool")
 tool_mod.function_tool = lambda f: f
 sys.modules.setdefault("agents.tool", tool_mod)
 
-from app.main import app, rpg_projects
+from app.main import app
 
 
 @pytest.fixture
-def client():
+def client(rpg_graphiti_store):
     with patch("app.main.graphiti_manager.initialize", AsyncMock()), \
          patch("app.main.cinegraph_agent.initialize", AsyncMock()), \
          patch("app.main.alert_manager.start_listening", AsyncMock()):
@@ -48,25 +48,20 @@ def client():
         yield test_client
 
 
-@pytest.fixture(autouse=True)
-def clear_projects():
-    rpg_projects.clear()
-    yield
-    rpg_projects.clear()
 
 
-def test_project_workflow(client):
+def test_project_workflow(client, rpg_graphiti_store):
     project_data = {"name": "Demo", "version": "MZ", "genre": "fantasy"}
     resp = client.post("/api/rpg-projects", json=project_data)
     assert resp.status_code == 200
     result = resp.json()
     project_id = result["project_id"]
-    assert project_id in rpg_projects
+    assert project_id in rpg_graphiti_store
 
     story = {"story_id": "s1", "content": "Once upon a time"}
     resp = client.post(f"/api/rpg-projects/{project_id}/sync-story", json=story)
     assert resp.status_code == 200
-    assert rpg_projects[project_id]["stories"]["s1"] == "Once upon a time"
+    assert rpg_graphiti_store[project_id]["stories"]["s1"] == "Once upon a time"
 
     config = {
         "project": project_data,
@@ -90,7 +85,7 @@ def test_project_workflow(client):
     assert len(data["export_configs"]) == 1
 
 
-def test_variable_and_switch_endpoints(client):
+def test_variable_and_switch_endpoints(client, rpg_graphiti_store):
     project_data = {"name": "Vars", "version": "MZ", "genre": "fantasy"}
     resp = client.post("/api/rpg-projects", json=project_data)
     project_id = resp.json()["project_id"]
@@ -104,7 +99,7 @@ def test_variable_and_switch_endpoints(client):
     }
     resp = client.post(f"/api/rpg-projects/{project_id}/variables", json=variable)
     assert resp.status_code == 200
-    assert len(rpg_projects[project_id]["variables"]) == 1
+    assert len(rpg_graphiti_store[project_id]["variables"]) == 1
 
     resp = client.get(f"/api/rpg-projects/{project_id}/variables")
     assert resp.status_code == 200
@@ -115,7 +110,7 @@ def test_variable_and_switch_endpoints(client):
     switch = {"name": "Door", "is_on": False, "scope": "global"}
     resp = client.post(f"/api/rpg-projects/{project_id}/switches", json=switch)
     assert resp.status_code == 200
-    assert len(rpg_projects[project_id]["switches"]) == 1
+    assert len(rpg_graphiti_store[project_id]["switches"]) == 1
 
     resp = client.get(f"/api/rpg-projects/{project_id}/switches")
     assert resp.status_code == 200
@@ -123,7 +118,7 @@ def test_variable_and_switch_endpoints(client):
     assert data["switches"][0]["name"] == "Door"
 
 
-def test_generate_and_sync_variables(client):
+def test_generate_and_sync_variables(client, rpg_graphiti_store):
     project_data = {"name": "Generate", "version": "MZ", "genre": "fantasy"}
     resp = client.post("/api/rpg-projects", json=project_data)
     project_id = resp.json()["project_id"]
@@ -147,7 +142,7 @@ def test_generate_and_sync_variables(client):
             f"/api/rpg-projects/{project_id}/variables/generate-from-story"
         )
         assert resp.status_code == 200
-        assert len(rpg_projects[project_id]["variables"]) == 1
+        assert len(rpg_graphiti_store[project_id]["variables"]) == 1
 
         mock_gen.generate_variables.assert_called_once()
 
@@ -165,5 +160,5 @@ def test_generate_and_sync_variables(client):
             f"/api/rpg-projects/{project_id}/variables/HeroHP/story-sync"
         )
         assert resp.status_code == 200
-        assert rpg_projects[project_id]["variables"][0].value == 75
+        assert rpg_graphiti_store[project_id]["variables"][0].value == 75
 


### PR DESCRIPTION
## Summary
- persist RPG project data via `GraphitiManager`
- extend `GraphitiManager` with RPG helpers
- mock GraphitiManager in tests
- document Neo4j variables in `.env.example`

## Testing
- `pip install -r requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6874125a1e108327b1ad0ab5bc2011e2