### PR TITLE
Add quest and dialogue generators

### DIFF
--- a/backend/game/dialogue_generator.py
+++ b/backend/game/dialogue_generator.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Utility for generating dialogue trees from story interactions."""
+
+from typing import Any
+
+from .models import DialogueTree
+from .relationship_analyzer import CharacterRelationshipAnalyzer
+
+
+class StoryDialogueGenerator:
+    """Generate ``DialogueTree`` objects using a CineGraphAgent."""
+
+    def __init__(self, agent: Any, relationship_analyzer: CharacterRelationshipAnalyzer) -> None:
+        self.agent = agent
+        self.relationship_analyzer = relationship_analyzer
+
+    async def generate_dialogue_from_story_interaction(
+        self, story_id: str, interaction_id: str
+    ) -> DialogueTree:
+        """Generate a dialogue tree based on a story interaction."""
+        relationships = await self.relationship_analyzer.analyze_relationships(story_id)
+        data = await self.agent.generate_dialogue_from_story_interaction(
+            story_id, interaction_id, relationships
+        )
+        return DialogueTree(**data)

--- a/backend/game/quest_generator.py
+++ b/backend/game/quest_generator.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Utility for generating quests from analyzed story events."""
+
+from typing import Any
+
+from .models import RPGQuest
+from .relationship_analyzer import CharacterRelationshipAnalyzer
+
+
+class StoryQuestGenerator:
+    """Generate ``RPGQuest`` objects using a CineGraphAgent."""
+
+    def __init__(self, agent: Any, relationship_analyzer: CharacterRelationshipAnalyzer) -> None:
+        self.agent = agent
+        self.relationship_analyzer = relationship_analyzer
+
+    async def generate_quest_from_story_event(self, story_id: str, event_id: str) -> RPGQuest:
+        """Generate a quest based on a story event.
+
+        The agent should expose ``generate_quest_from_story_event`` which takes
+        ``story_id``, ``event_id`` and a list of character relationships.
+        """
+        relationships = await self.relationship_analyzer.analyze_relationships(story_id)
+        data = await self.agent.generate_quest_from_story_event(story_id, event_id, relationships)
+        return RPGQuest(**data)

--- a/backend/game/relationship_analyzer.py
+++ b/backend/game/relationship_analyzer.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Analyze character relationships using a CineGraphAgent."""
+
+from typing import Any, List, Dict
+
+
+class CharacterRelationshipAnalyzer:
+    """Fetch character relationships from the knowledge graph."""
+
+    def __init__(self, agent: Any) -> None:
+        self.agent = agent
+
+    async def analyze_relationships(self, story_id: str) -> List[Dict[str, Any]]:
+        """Return relationships for the given story.
+
+        This queries the knowledge graph via ``graph_query``. Each returned item
+        should describe a relationship with ``from_character``, ``to_character``
+        and ``relationship_type`` keys.
+        """
+        query = (
+            "MATCH (a:Character)-[r]->(b:Character) "
+            "WHERE r.story_id = $story_id "
+            "RETURN a.name AS from_character, b.name AS to_character, "
+            "type(r) AS relationship_type"
+        )
+        result = await self.agent.graph_query(query, {"story_id": story_id})
+        return result.get("data", [])

--- a/backend/tests/test_dialogue_generator.py
+++ b/backend/tests/test_dialogue_generator.py
@@ -1,0 +1,40 @@
+"""Tests for StoryDialogueGenerator."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from game.dialogue_generator import StoryDialogueGenerator
+from game.models import DialogueTree
+
+
+@pytest.mark.asyncio
+async def test_generate_dialogue_from_interaction():
+    agent = Mock()
+    agent.generate_dialogue_from_story_interaction = AsyncMock(return_value={
+        "id": "dlg1",
+        "start_node_id": "n1",
+        "nodes": [
+            {"id": "n1", "speaker": "Alice", "text": "Hello", "choices": []}
+        ],
+        "description": "Greeting"
+    })
+
+    analyzer = Mock()
+    analyzer.analyze_relationships = AsyncMock(return_value=[{"from": "Alice", "to": "Bob", "type": "FRIENDS_WITH"}])
+
+    generator = StoryDialogueGenerator(agent, analyzer)
+    dialogue = await generator.generate_dialogue_from_story_interaction("story1", "inter1")
+
+    analyzer.analyze_relationships.assert_called_once_with("story1")
+    agent.generate_dialogue_from_story_interaction.assert_called_once_with(
+        "story1", "inter1", [{"from": "Alice", "to": "Bob", "type": "FRIENDS_WITH"}]
+    )
+
+    assert isinstance(dialogue, DialogueTree)
+    assert dialogue.id == "dlg1"
+    assert dialogue.nodes[0].text == "Hello"

--- a/backend/tests/test_quest_generator.py
+++ b/backend/tests/test_quest_generator.py
@@ -1,0 +1,42 @@
+"""Tests for StoryQuestGenerator."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from game.quest_generator import StoryQuestGenerator
+from game.models import RPGQuest, QuestType, QuestStatus
+
+
+@pytest.mark.asyncio
+async def test_generate_quest_from_event():
+    agent = Mock()
+    agent.generate_quest_from_story_event = AsyncMock(return_value={
+        "name": "Retrieve Sword",
+        "quest_type": "main",
+        "status": "not_started",
+        "description": "Find the lost sword",
+        "objectives": [],
+        "rewards": ["Gold"],
+        "prerequisites": []
+    })
+
+    analyzer = Mock()
+    analyzer.analyze_relationships = AsyncMock(return_value=[{"from": "Alice", "to": "Bob", "type": "FRIENDS_WITH"}])
+
+    generator = StoryQuestGenerator(agent, analyzer)
+    quest = await generator.generate_quest_from_story_event("story1", "event1")
+
+    analyzer.analyze_relationships.assert_called_once_with("story1")
+    agent.generate_quest_from_story_event.assert_called_once_with(
+        "story1", "event1", [{"from": "Alice", "to": "Bob", "type": "FRIENDS_WITH"}]
+    )
+
+    assert isinstance(quest, RPGQuest)
+    assert quest.name == "Retrieve Sword"
+    assert quest.quest_type == QuestType.MAIN
+    assert quest.status == QuestStatus.NOT_STARTED


### PR DESCRIPTION
## Summary
- add `CharacterRelationshipAnalyzer` for querying relationships
- implement `StoryQuestGenerator` for generating quests from events
- implement `StoryDialogueGenerator` for dialogue tree creation
- add unit tests for new generators

## Testing
- `python -m py_compile game/quest_generator.py game/dialogue_generator.py game/relationship_analyzer.py`
- `pytest tests/test_quest_generator.py tests/test_dialogue_generator.py -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687422ee3c34832796e3be2d0eb4c382